### PR TITLE
CSS Update for Pelican 3.2

### DIFF
--- a/static/css/pygment-solarized-dark.css
+++ b/static/css/pygment-solarized-dark.css
@@ -1,70 +1,70 @@
-.codehilite pre { background-color: #002b36; color: #839496 }
-.codehilite .hll { background-color: #ffffcc }
-.codehilite .c { color: #586e75; font-style: italic } /* Comment */
-.codehilite .err { color: #dc322f } /* Error */
-.codehilite .g { color: #839496 } /* Generic */
-.codehilite .k { color: #859900 } /* Keyword */
-.codehilite .l { color: #839496 } /* Literal */
-.codehilite .n { color: #93a1a1 } /* Name */
-.codehilite .o { color: #839496 } /* Operator */
-.codehilite .x { color: #839496 } /* Other */
-.codehilite .p { color: #839496 } /* Punctuation */
-.codehilite .cm { color: #586e75; font-style: italic } /* Comment.Multiline */
-.codehilite .cp { color: #586e75; font-style: italic } /* Comment.Preproc */
-.codehilite .c1 { color: #586e75; font-style: italic } /* Comment.Single */
-.codehilite .cs { color: #586e75; font-style: italic } /* Comment.Special */
-.codehilite .gd { color: #839496 } /* Generic.Deleted */
-.codehilite .ge { color: #839496 } /* Generic.Emph */
-.codehilite .gr { color: #839496 } /* Generic.Error */
-.codehilite .gh { color: #839496 } /* Generic.Heading */
-.codehilite .gi { color: #839496 } /* Generic.Inserted */
-.codehilite .go { color: #839496 } /* Generic.Output */
-.codehilite .gp { color: #839496 } /* Generic.Prompt */
-.codehilite .gs { color: #839496 } /* Generic.Strong */
-.codehilite .gu { color: #839496 } /* Generic.Subheading */
-.codehilite .gt { color: #839496 } /* Generic.Traceback */
-.codehilite .kc { color: #859900 } /* Keyword.Constant */
-.codehilite .kd { color: #859900 } /* Keyword.Declaration */
-.codehilite .kn { color: #cb4b16 } /* Keyword.Namespace */
-.codehilite .kp { color: #cb4b16 } /* Keyword.Pseudo */
-.codehilite .kr { color: #859900 } /* Keyword.Reserved */
-.codehilite .kt { color: #859900 } /* Keyword.Type */
-.codehilite .ld { color: #839496 } /* Literal.Date */
-.codehilite .m { color: #2aa198 } /* Literal.Number */
-.codehilite .s { color: #2aa198 } /* Literal.String */
-.codehilite .na { color: #839496 } /* Name.Attribute */
-.codehilite .nb { color: #268bd2 } /* Name.Builtin */
-.codehilite .nc { color: #268bd2 } /* Name.Class */
-.codehilite .no { color: #b58900 } /* Name.Constant */
-.codehilite .nd { color: #cb4b16 } /* Name.Decorator */
-.codehilite .ni { color: #cb4b16 } /* Name.Entity */
-.codehilite .ne { color: #cb4b16 } /* Name.Exception */
-.codehilite .nf { color: #268bd2 } /* Name.Function */
-.codehilite .nl { color: #839496 } /* Name.Label */
-.codehilite .nn { color: #b58900 } /* Name.Namespace */
-.codehilite .nx { color: #839496 } /* Name.Other */
-.codehilite .py { color: #268bd2 } /* Name.Property */
-.codehilite .nt { color: #859900 } /* Name.Tag */
-.codehilite .nv { color: #cd4b16 } /* Name.Variable */
-.codehilite .ow { color: #859900 } /* Operator.Word */
-.codehilite .w { color: #002b36 } /* Text.Whitespace */
-.codehilite .mf { color: #2aa198 } /* Literal.Number.Float */
-.codehilite .mh { color: #2aa198 } /* Literal.Number.Hex */
-.codehilite .mi { color: #2aa198 } /* Literal.Number.Integer */
-.codehilite .mo { color: #2aa198 } /* Literal.Number.Oct */
-.codehilite .sb { color: #2aa198 } /* Literal.String.Backtick */
-.codehilite .sc { color: #2aa198 } /* Literal.String.Char */
-.codehilite .sd { color: #2aa198 } /* Literal.String.Doc */
-.codehilite .s2 { color: #2aa198 } /* Literal.String.Double */
-.codehilite .se { color: #cb4b16 } /* Literal.String.Escape */
-.codehilite .sh { color: #2aa198 } /* Literal.String.Heredoc */
-.codehilite .si { color: #cb4b16 } /* Literal.String.Interpol */
-.codehilite .sx { color: #2aa198 } /* Literal.String.Other */
-.codehilite .sr { color: #2aa198 } /* Literal.String.Regex */
-.codehilite .s1 { color: #2aa198 } /* Literal.String.Single */
-.codehilite .ss { color: #2aa198 } /* Literal.String.Symbol */
-.codehilite .bp { color: #268bd2; font-weight: bold } /* Name.Builtin.Pseudo */
-.codehilite .vc { color: #268bd2 } /* Name.Variable.Class */
-.codehilite .vg { color: #268bd2 } /* Name.Variable.Global */
-.codehilite .vi { color: #268bd2 } /* Name.Variable.Instance */
-.codehilite .il { color: #2aa198 } /* Literal.Number.Integer.Long */
+.highlight pre { background-color: #002b36; color: #839496 }
+.highlight .hll { background-color: #ffffcc }
+.highlight .c { color: #586e75; font-style: italic } /* Comment */
+.highlight .err { color: #dc322f } /* Error */
+.highlight .g { color: #839496 } /* Generic */
+.highlight .k { color: #859900 } /* Keyword */
+.highlight .l { color: #839496 } /* Literal */
+.highlight .n { color: #93a1a1 } /* Name */
+.highlight .o { color: #839496 } /* Operator */
+.highlight .x { color: #839496 } /* Other */
+.highlight .p { color: #839496 } /* Punctuation */
+.highlight .cm { color: #586e75; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #586e75; font-style: italic } /* Comment.Preproc */
+.highlight .c1 { color: #586e75; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #586e75; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #839496 } /* Generic.Deleted */
+.highlight .ge { color: #839496 } /* Generic.Emph */
+.highlight .gr { color: #839496 } /* Generic.Error */
+.highlight .gh { color: #839496 } /* Generic.Heading */
+.highlight .gi { color: #839496 } /* Generic.Inserted */
+.highlight .go { color: #839496 } /* Generic.Output */
+.highlight .gp { color: #839496 } /* Generic.Prompt */
+.highlight .gs { color: #839496 } /* Generic.Strong */
+.highlight .gu { color: #839496 } /* Generic.Subheading */
+.highlight .gt { color: #839496 } /* Generic.Traceback */
+.highlight .kc { color: #859900 } /* Keyword.Constant */
+.highlight .kd { color: #859900 } /* Keyword.Declaration */
+.highlight .kn { color: #cb4b16 } /* Keyword.Namespace */
+.highlight .kp { color: #cb4b16 } /* Keyword.Pseudo */
+.highlight .kr { color: #859900 } /* Keyword.Reserved */
+.highlight .kt { color: #859900 } /* Keyword.Type */
+.highlight .ld { color: #839496 } /* Literal.Date */
+.highlight .m { color: #2aa198 } /* Literal.Number */
+.highlight .s { color: #2aa198 } /* Literal.String */
+.highlight .na { color: #839496 } /* Name.Attribute */
+.highlight .nb { color: #268bd2 } /* Name.Builtin */
+.highlight .nc { color: #268bd2 } /* Name.Class */
+.highlight .no { color: #b58900 } /* Name.Constant */
+.highlight .nd { color: #cb4b16 } /* Name.Decorator */
+.highlight .ni { color: #cb4b16 } /* Name.Entity */
+.highlight .ne { color: #cb4b16 } /* Name.Exception */
+.highlight .nf { color: #268bd2 } /* Name.Function */
+.highlight .nl { color: #839496 } /* Name.Label */
+.highlight .nn { color: #b58900 } /* Name.Namespace */
+.highlight .nx { color: #839496 } /* Name.Other */
+.highlight .py { color: #268bd2 } /* Name.Property */
+.highlight .nt { color: #859900 } /* Name.Tag */
+.highlight .nv { color: #cd4b16 } /* Name.Variable */
+.highlight .ow { color: #859900 } /* Operator.Word */
+.highlight .w { color: #002b36 } /* Text.Whitespace */
+.highlight .mf { color: #2aa198 } /* Literal.Number.Float */
+.highlight .mh { color: #2aa198 } /* Literal.Number.Hex */
+.highlight .mi { color: #2aa198 } /* Literal.Number.Integer */
+.highlight .mo { color: #2aa198 } /* Literal.Number.Oct */
+.highlight .sb { color: #2aa198 } /* Literal.String.Backtick */
+.highlight .sc { color: #2aa198 } /* Literal.String.Char */
+.highlight .sd { color: #2aa198 } /* Literal.String.Doc */
+.highlight .s2 { color: #2aa198 } /* Literal.String.Double */
+.highlight .se { color: #cb4b16 } /* Literal.String.Escape */
+.highlight .sh { color: #2aa198 } /* Literal.String.Heredoc */
+.highlight .si { color: #cb4b16 } /* Literal.String.Interpol */
+.highlight .sx { color: #2aa198 } /* Literal.String.Other */
+.highlight .sr { color: #2aa198 } /* Literal.String.Regex */
+.highlight .s1 { color: #2aa198 } /* Literal.String.Single */
+.highlight .ss { color: #2aa198 } /* Literal.String.Symbol */
+.highlight .bp { color: #268bd2; font-weight: bold } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #268bd2 } /* Name.Variable.Class */
+.highlight .vg { color: #268bd2 } /* Name.Variable.Global */
+.highlight .vi { color: #268bd2 } /* Name.Variable.Instance */
+.highlight .il { color: #2aa198 } /* Literal.Number.Integer.Long */

--- a/static/css/pygment-solarized-light.css
+++ b/static/css/pygment-solarized-light.css
@@ -1,70 +1,70 @@
-.codehilite pre { background-color: #fdf6e3; color: #657b83 }
-.codehilite .hll { background-color: #ffffcc }
-.codehilite .c { color: #93a1a1; font-style: italic } /* Comment */
-.codehilite .err { color: #dc322f } /* Error */
-.codehilite .g { color: #657b83 } /* Generic */
-.codehilite .k { color: #859900 } /* Keyword */
-.codehilite .l { color: #657b83 } /* Literal */
-.codehilite .n { color: #586e75 } /* Name */
-.codehilite .o { color: #657b83 } /* Operator */
-.codehilite .x { color: #657b83 } /* Other */
-.codehilite .p { color: #657b83 } /* Punctuation */
-.codehilite .cm { color: #93a1a1; font-style: italic } /* Comment.Multiline */
-.codehilite .cp { color: #93a1a1; font-style: italic } /* Comment.Preproc */
-.codehilite .c1 { color: #93a1a1; font-style: italic } /* Comment.Single */
-.codehilite .cs { color: #93a1a1; font-style: italic } /* Comment.Special */
-.codehilite .gd { color: #657b83 } /* Generic.Deleted */
-.codehilite .ge { color: #657b83 } /* Generic.Emph */
-.codehilite .gr { color: #657b83 } /* Generic.Error */
-.codehilite .gh { color: #657b83 } /* Generic.Heading */
-.codehilite .gi { color: #657b83 } /* Generic.Inserted */
-.codehilite .go { color: #657b83 } /* Generic.Output */
-.codehilite .gp { color: #657b83 } /* Generic.Prompt */
-.codehilite .gs { color: #657b83 } /* Generic.Strong */
-.codehilite .gu { color: #657b83 } /* Generic.Subheading */
-.codehilite .gt { color: #657b83 } /* Generic.Traceback */
-.codehilite .kc { color: #859900 } /* Keyword.Constant */
-.codehilite .kd { color: #859900 } /* Keyword.Declaration */
-.codehilite .kn { color: #cb4b16 } /* Keyword.Namespace */
-.codehilite .kp { color: #cb4b16 } /* Keyword.Pseudo */
-.codehilite .kr { color: #859900 } /* Keyword.Reserved */
-.codehilite .kt { color: #859900 } /* Keyword.Type */
-.codehilite .ld { color: #657b83 } /* Literal.Date */
-.codehilite .m { color: #2aa198 } /* Literal.Number */
-.codehilite .s { color: #2aa198 } /* Literal.String */
-.codehilite .na { color: #657b83 } /* Name.Attribute */
-.codehilite .nb { color: #268bd2 } /* Name.Builtin */
-.codehilite .nc { color: #268bd2 } /* Name.Class */
-.codehilite .no { color: #b58900 } /* Name.Constant */
-.codehilite .nd { color: #cb4b16 } /* Name.Decorator */
-.codehilite .ni { color: #cb4b16 } /* Name.Entity */
-.codehilite .ne { color: #cb4b16 } /* Name.Exception */
-.codehilite .nf { color: #268bd2 } /* Name.Function */
-.codehilite .nl { color: #657b83 } /* Name.Label */
-.codehilite .nn { color: #b58900 } /* Name.Namespace */
-.codehilite .nx { color: #657b83 } /* Name.Other */
-.codehilite .py { color: #268bd2 } /* Name.Property */
-.codehilite .nt { color: #859900 } /* Name.Tag */
-.codehilite .nv { color: #cd4b16 } /* Name.Variable */
-.codehilite .ow { color: #859900 } /* Operator.Word */
-.codehilite .w { color: #fdf6e3 } /* Text.Whitespace */
-.codehilite .mf { color: #2aa198 } /* Literal.Number.Float */
-.codehilite .mh { color: #2aa198 } /* Literal.Number.Hex */
-.codehilite .mi { color: #2aa198 } /* Literal.Number.Integer */
-.codehilite .mo { color: #2aa198 } /* Literal.Number.Oct */
-.codehilite .sb { color: #2aa198 } /* Literal.String.Backtick */
-.codehilite .sc { color: #2aa198 } /* Literal.String.Char */
-.codehilite .sd { color: #2aa198 } /* Literal.String.Doc */
-.codehilite .s2 { color: #2aa198 } /* Literal.String.Double */
-.codehilite .se { color: #cb4b16 } /* Literal.String.Escape */
-.codehilite .sh { color: #2aa198 } /* Literal.String.Heredoc */
-.codehilite .si { color: #cb4b16 } /* Literal.String.Interpol */
-.codehilite .sx { color: #2aa198 } /* Literal.String.Other */
-.codehilite .sr { color: #2aa198 } /* Literal.String.Regex */
-.codehilite .s1 { color: #2aa198 } /* Literal.String.Single */
-.codehilite .ss { color: #2aa198 } /* Literal.String.Symbol */
-.codehilite .bp { color: #268bd2; font-weight: bold } /* Name.Builtin.Pseudo */
-.codehilite .vc { color: #268bd2 } /* Name.Variable.Class */
-.codehilite .vg { color: #268bd2 } /* Name.Variable.Global */
-.codehilite .vi { color: #268bd2 } /* Name.Variable.Instance */
-.codehilite .il { color: #2aa198 } /* Literal.Number.Integer.Long */
+.highlight pre { background-color: #fdf6e3; color: #657b83 }
+.highlight .hll { background-color: #ffffcc }
+.highlight .c { color: #93a1a1; font-style: italic } /* Comment */
+.highlight .err { color: #dc322f } /* Error */
+.highlight .g { color: #657b83 } /* Generic */
+.highlight .k { color: #859900 } /* Keyword */
+.highlight .l { color: #657b83 } /* Literal */
+.highlight .n { color: #586e75 } /* Name */
+.highlight .o { color: #657b83 } /* Operator */
+.highlight .x { color: #657b83 } /* Other */
+.highlight .p { color: #657b83 } /* Punctuation */
+.highlight .cm { color: #93a1a1; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #93a1a1; font-style: italic } /* Comment.Preproc */
+.highlight .c1 { color: #93a1a1; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #93a1a1; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #657b83 } /* Generic.Deleted */
+.highlight .ge { color: #657b83 } /* Generic.Emph */
+.highlight .gr { color: #657b83 } /* Generic.Error */
+.highlight .gh { color: #657b83 } /* Generic.Heading */
+.highlight .gi { color: #657b83 } /* Generic.Inserted */
+.highlight .go { color: #657b83 } /* Generic.Output */
+.highlight .gp { color: #657b83 } /* Generic.Prompt */
+.highlight .gs { color: #657b83 } /* Generic.Strong */
+.highlight .gu { color: #657b83 } /* Generic.Subheading */
+.highlight .gt { color: #657b83 } /* Generic.Traceback */
+.highlight .kc { color: #859900 } /* Keyword.Constant */
+.highlight .kd { color: #859900 } /* Keyword.Declaration */
+.highlight .kn { color: #cb4b16 } /* Keyword.Namespace */
+.highlight .kp { color: #cb4b16 } /* Keyword.Pseudo */
+.highlight .kr { color: #859900 } /* Keyword.Reserved */
+.highlight .kt { color: #859900 } /* Keyword.Type */
+.highlight .ld { color: #657b83 } /* Literal.Date */
+.highlight .m { color: #2aa198 } /* Literal.Number */
+.highlight .s { color: #2aa198 } /* Literal.String */
+.highlight .na { color: #657b83 } /* Name.Attribute */
+.highlight .nb { color: #268bd2 } /* Name.Builtin */
+.highlight .nc { color: #268bd2 } /* Name.Class */
+.highlight .no { color: #b58900 } /* Name.Constant */
+.highlight .nd { color: #cb4b16 } /* Name.Decorator */
+.highlight .ni { color: #cb4b16 } /* Name.Entity */
+.highlight .ne { color: #cb4b16 } /* Name.Exception */
+.highlight .nf { color: #268bd2 } /* Name.Function */
+.highlight .nl { color: #657b83 } /* Name.Label */
+.highlight .nn { color: #b58900 } /* Name.Namespace */
+.highlight .nx { color: #657b83 } /* Name.Other */
+.highlight .py { color: #268bd2 } /* Name.Property */
+.highlight .nt { color: #859900 } /* Name.Tag */
+.highlight .nv { color: #cd4b16 } /* Name.Variable */
+.highlight .ow { color: #859900 } /* Operator.Word */
+.highlight .w { color: #fdf6e3 } /* Text.Whitespace */
+.highlight .mf { color: #2aa198 } /* Literal.Number.Float */
+.highlight .mh { color: #2aa198 } /* Literal.Number.Hex */
+.highlight .mi { color: #2aa198 } /* Literal.Number.Integer */
+.highlight .mo { color: #2aa198 } /* Literal.Number.Oct */
+.highlight .sb { color: #2aa198 } /* Literal.String.Backtick */
+.highlight .sc { color: #2aa198 } /* Literal.String.Char */
+.highlight .sd { color: #2aa198 } /* Literal.String.Doc */
+.highlight .s2 { color: #2aa198 } /* Literal.String.Double */
+.highlight .se { color: #cb4b16 } /* Literal.String.Escape */
+.highlight .sh { color: #2aa198 } /* Literal.String.Heredoc */
+.highlight .si { color: #cb4b16 } /* Literal.String.Interpol */
+.highlight .sx { color: #2aa198 } /* Literal.String.Other */
+.highlight .sr { color: #2aa198 } /* Literal.String.Regex */
+.highlight .s1 { color: #2aa198 } /* Literal.String.Single */
+.highlight .ss { color: #2aa198 } /* Literal.String.Symbol */
+.highlight .bp { color: #268bd2; font-weight: bold } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #268bd2 } /* Name.Variable.Class */
+.highlight .vg { color: #268bd2 } /* Name.Variable.Global */
+.highlight .vi { color: #268bd2 } /* Name.Variable.Instance */
+.highlight .il { color: #2aa198 } /* Literal.Number.Integer.Long */


### PR DESCRIPTION
This fixed the syntax highlighting on my local version of Pelican, running 3.2.  See if this works for you.
