### PR TITLE
Fixed the feed links and added a feed icon at the bottom for easy access

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -48,17 +48,17 @@
     {% if FEED_RSS %}
       <link href="{{ FEED_DOMAIN }}/{{ FEED_RSS }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} RSS Feed"/>
     {% endif %}
-    {% if CATEGORY_FEED_ATOM %}
-      <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_ATOM|format(category) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Categories Atom Feed"/>
+    {% if CATEGORY_FEED_ATOM and category is defined %}
+      <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_ATOM|format(category.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Categories Atom Feed"/>
     {% endif %}
-    {% if CATEGORY_FEED_RSS %}
-      <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_RSS|format(category) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Categories RSS Feed"/>
+    {% if CATEGORY_FEED_RSS and category is defined %}
+      <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_RSS|format(category.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Categories RSS Feed"/>
     {% endif %}
-    {% if TAG_FEED_ATOM %}
-      <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_ATOM|format(tag) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Tags Atom Feed"/>
+    {% if TAG_FEED_ATOM and tag is defined %}
+      <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_ATOM|format(tag.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Tags Atom Feed"/>
     {% endif %}
-    {% if TAG_FEED_RSS %}
-      <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_RSS|format(tag) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Tags RSS Feed"/>
+    {% if TAG_FEED_RSS and tag is defined %}
+      <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_RSS|format(tag.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Tags RSS Feed"/>
     {% endif %}
 
     {% block head %}
@@ -180,6 +180,20 @@
               {% endif %}
               {% if TAGS_SAVE_AS %}
                 <li><a href="{{ SITEURL }}/{{ TAGS_SAVE_AS }}" class="icon-tag"> Tags</a></li>
+              {% endif %}
+
+              {% if TAG_FEED_ATOM and tag is defined %}
+                <li><a href="{{ FEED_DOMAIN }}/{{ TAG_FEED_ATOM|format(tag.slug) }}" class="icon-rss"> Feed</a></li>
+              {% elif TAG_FEED_RSS and tag is defined %}
+                <li><a href="{{ FEED_DOMAIN }}/{{ TAG_FEED_RSS|format(tag.slug) }}" class="icon-rss"> Feed</a></li>
+              {% elif CATEGORY_FEED_ATOM and category is defined %}
+                <li><a href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_ATOM|format(category.slug) }}" class="icon-rss"> Feed</a></li>
+              {% elif CATEGORY_FEED_RSS and category is defined %}
+                <li><a href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_RSS|format(category.slug) }}" class="icon-rss"> Feed</a></li>
+              {% elif FEED_ALL_ATOM %}
+                <li><a href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}" class="icon-rss"> Feed</a></li>
+              {% elif FEED_ALL_RSS %}
+                <li><a href="{{ FEED_DOMAIN }}/{{ FEED_ALL_RSS }}" class="icon-rss"> Feed</a></li>
               {% endif %}
             </ul>
           </div>


### PR DESCRIPTION
Half this commit is bugfix: use tag.slug and category.slug for the feed links. There is a difference with non-lowercased tags and categories.

The other half of this commit is adding a **Feed** link at the end of the **Browse content by** list. This may not be the ideal place for such a link... but I couldn't come with a better idea.
