### PR TITLE
Add PLUMAGE_GRAB_ICONS option

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -158,7 +158,7 @@
                 <h5>{{ group_title }}</h5>
                 <ul class="unstyled">
                 {% for title, link in group_links %}
-                  <li>{{ m.render_link_icon(link, title) }}</li>
+                  <li>{{ m.render_link_icon(link, title, PLUMAGE_GRAB_ICONS) }}</li>
                 {% endfor %}
                 </ul>
               {% endif %}

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -2,7 +2,7 @@
   <a href="{{ SITEURL }}/{{ tag.url }}" rel="tooltip" class="label" data-placement="right" data-original-title="{{ tag.articles }} article{{ 's' if tag.articles > 1 else '' }} with this tag">{{ tag.name }}</a>
 {%- endmacro %}
 
-{% macro render_link_icon(link, label) -%}
+{% macro render_link_icon(link, label, grabicon=False) -%}
   {% set icon = [] %}
   {% set protocol = link.split(':', 1)[0] %}
   {% if protocol == 'mailto' %}
@@ -34,7 +34,7 @@
   <a href="{{ link }}">
     {% if icon %}
       <i class="fa {{ 'fa-%s' % icon[0] }}"></i>
-    {% elif not icon and domain %}
+    {% elif not icon and domain and grabicon %}
       <img src="http://grabicon.com/icon?domain={{ domain }}&size=16" width="16" height="16" class="icon" alt="{{ domain }} icon"/>
     {% endif %}
     {{ label }}


### PR DESCRIPTION
Plumage gets favicons from grabicons paying service. Add a
PLUMAGE_GRAB_ICONS option defaulting to False to avoid using that
service. If a user is paying for grabicons service and wants to use it,
then he just needs to add PLUMAGE_GRAB_ICONS = True to his pelican
config.