### PR TITLE
Add support for Google Analytics Universal

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Setting name | Default value | Description
 `DISCLAIMER` | | Overide the Disclaimer notice that gets displayed at the fourth column of the footer.
 `DISQUS_SITENAME` | | Pelican can handle Disqus comments. Specify the Disqus sitename identifier here.
 `GOOGLE_ANALYTICS` | | Set to `UA-XXXX-YYYY` to activate Google Analytics.
+`GOOGLE_ANALYTICS_UNIVERSAL` | | Set to `UA-XXXXXXXX-Y` to activate newer Google Analytics Universal.
+`GOOGLE_ANALYTICS_UNIVERSAL_PROPERTY` | | Set to property like `auto` for newer Google Analytics Universal.
 `GOOGLE_SEARCH` | | [Google's Custom Search Engine](https://www.google.com/cse/) ID (e.g. `partner-pub-0123456789098765:0123456789`) to activate blog specific search.
 `GRAB_ICONS` | `False` | Fetch link's icons from the grabicon.com web service.
 `LEFT_SIDEBAR` | | HTML content to put as-is in the left sidebar.

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -10,6 +10,18 @@
     })();
     </script>
 {% endif %}
+{% if GOOGLE_ANALYTICS_UNIVERSAL %}
+    <!-- Google Analytics Universal -->
+    <script type="text/javascript">
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        ga('create', '{{ GOOGLE_ANALYTICS_UNIVERSAL }}', '{{ GOOGLE_ANALYTICS_UNIVERSAL_PROPERTY }}');
+        ga('send', 'pageview');
+    </script>
+    <!-- End Google Analytics Universal Code -->
+{% endif %}
 
 {% if PIWIK_URL and PIWIK_SITE_ID %}
     <script type="text/javascript">


### PR DESCRIPTION
It seems Google Analytics Universal superseded Google Analytics. The necessary bits were added to include support for the configuration options GOOGLE_ANALYTICS_UNIVERSAL and GOOGLE_ANALYTICS_UNIVERSAL_PROPERTY as in many other themes.