### PR TITLE
Allow for non-zoomable images

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ The theme uses external softwares, scripts, libraries and artworks:
     Copyright (c) 2012 Younès El Biache
     Distributed under a MIT license
     Source: https://github.com/younes0/jQuery-MGlass
+    Note: Use *noZoom* as class to omit the magnifying glass
 
     Solarized Pygment style v0.1.0
     Copyright (c) 2012 Shoji KUMAGAI

--- a/static/js/application.js
+++ b/static/js/application.js
@@ -62,20 +62,26 @@
       var link_tag = $(this).closest('a');
       if (parse_youtube_url(link_tag.attr('href')) != false) {
         link_tag.addClass("video");
-      } else {
-        // Activate zoom popup
-        link_tag.magnificPopup({
-          type: 'image',
-          closeOnContentClick: true,
-          midClick: true,
-          mainClass: 'mfp-with-zoom',
-          zoom: {
-            enabled: true,
-            duration: 300,
-            easing: 'ease-in-out',
-          },
-        });
-      };
+        return;
+      }
+      // No zoom popup for class noZoom
+      if ($(this).hasClass( "noZoom" )) {
+        return;
+      }
+
+      // Activate zoom popup
+      link_tag.magnificPopup({
+        type: 'image',
+        closeOnContentClick: true,
+        midClick: true,
+        mainClass: 'mfp-with-zoom',
+        zoom: {
+          enabled: true,
+          duration: 300,
+          easing: 'ease-in-out',
+        },
+      });
+
       // Add overlay zoom icon
       $(this).mglass({opacity: 1,});
     });


### PR DESCRIPTION
The magnifying glass feature is neat but sometimes it might be unwanted. Defining an img tag with class=noZoom omits this feature.