### PR TITLE
Fixed base.html for pelican 4.x

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -49,16 +49,16 @@
       {% if all_feeds.append({'kind': 'RSS', 'url': FEED_RSS, 'name': 'Latest posts'}) %}{% endif %}
     {% endif %}
     {% if CATEGORY_FEED_ATOM and category is defined %}
-      {% if all_feeds.append({'kind': 'Atom', 'url': CATEGORY_FEED_ATOM|format(category.slug), 'name': 'Category: ' + category.name}) %}{% endif %}
+      {% if all_feeds.append({'kind': 'Atom', 'url': CATEGORY_FEED_ATOM.format(slug=category.slug), 'name': 'Category: ' + category.name}) %}{% endif %}
     {% endif %}
     {% if CATEGORY_FEED_RSS and category is defined %}
-      {% if all_feeds.append({'kind': 'RSS', 'url': CATEGORY_FEED_RSS|format(category.slug), 'name': 'Category: ' + category.name}) %}{% endif %}
+      {% if all_feeds.append({'kind': 'RSS', 'url': CATEGORY_FEED_RSS.format(slug=category.slug), 'name': 'Category: ' + category.name}) %}{% endif %}
     {% endif %}
     {% if TAG_FEED_ATOM and tag is defined %}
-      {% if all_feeds.append({'kind': 'Atom', 'url': TAG_FEED_ATOM|format(tag.slug), 'name': 'Tag: ' + tag.name}) %}{% endif %}
+      {% if all_feeds.append({'kind': 'Atom', 'url': TAG_FEED_ATOM.format(slug=tag.slug), 'name': 'Tag: ' + tag.name}) %}{% endif %}
     {% endif %}
     {% if TAG_FEED_RSS and tag is defined %}
-      {% if all_feeds.append({'kind': 'RSS', 'url': TAG_FEED_RSS|format(tag.slug), 'name': 'Tag: ' + tag.name}) %}{% endif %}
+      {% if all_feeds.append({'kind': 'RSS', 'url': TAG_FEED_RSS.format(slug=tag.slug), 'name': 'Tag: ' + tag.name}) %}{% endif %}
     {% endif %}
     {% for feed in all_feeds %}
       <link href="{{ FEED_DOMAIN }}/{{ feed.url }}" type="application/{{ feed.kind|lower }}+xml" rel="alternate" title="{{ SITENAME|e }} - {{ feed.name|e }} - {{ feed.kind }} Feed"/>


### PR DESCRIPTION
With current base.html from plumage theme and pelican 4/python3, it's not possible to render content anymore.
```
DEBUG: Pelican version: 4.1.3
DEBUG: Python version: 3.6.8
```
The error is : 

```
CRITICAL: TypeError: not all arguments converted during string formatting
Traceback (most recent call last):
  File "/home/arrfab/virtualenvs/pelican/bin/pelican", line 8, in <module>
    sys.exit(main())
  File "/home/arrfab/virtualenvs/pelican/lib/python3.6/site-packages/pelican/__init__.py", line 570, in main
    pelican.run()
  File "/home/arrfab/virtualenvs/pelican/lib/python3.6/site-packages/pelican/__init__.py", line 137, in run
    p.generate_output(writer)
  File "/home/arrfab/virtualenvs/pelican/lib/python3.6/site-packages/pelican/generators.py", line 689, in generate_output
    self.generate_pages(writer)
  File "/home/arrfab/virtualenvs/pelican/lib/python3.6/site-packages/pelican/generators.py", line 598, in generate_pages
    self.generate_articles(write)
  File "/home/arrfab/virtualenvs/pelican/lib/python3.6/site-packages/pelican/generators.py", line 470, in generate_articles
    url=article.url, blog=True)
  File "/home/arrfab/virtualenvs/pelican/lib/python3.6/site-packages/pelican/writers.py", line 272, in write_file
    override_output)
  File "/home/arrfab/virtualenvs/pelican/lib/python3.6/site-packages/pelican/writers.py", line 204, in _write_file
    output = template.render(localcontext)
  File "/home/arrfab/virtualenvs/pelican/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/home/arrfab/virtualenvs/pelican/lib/python3.6/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/arrfab/virtualenvs/pelican/lib/python3.6/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/arrfab/virtualenvs/pelican/lib/python3.6/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "/home/arrfab/Documents/Private/blog/pelican/themes/plumage/templates/article.html", line 3, in top-level template code
    {% set has_right = True %}
  File "/home/arrfab/Documents/Private/blog/pelican/themes/plumage/templates/base.html", line 48, in top-level template code
    <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_ATOM|format(category.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME|e }} Categories Atom Feed"/>
  File "/home/arrfab/virtualenvs/pelican/lib/python3.6/site-packages/jinja2/filters.py", line 685, in do_format
    return soft_unicode(value) % (kwargs or args)
TypeError: not all arguments converted during string formatting

```
This PR is based on the same issue that was fixed in upstream pelican itself for base (see https://github.com/getpelican/pelican/pull/2515/files) and so fix this issue


Signed-off-by: Fabian Arrotin <fabian.arrotin@arrfab.net>