### PR TITLE
Format Jinja

### DIFF
--- a/plumage/templates/base.html
+++ b/plumage/templates/base.html
@@ -344,7 +344,9 @@ the block emits lands inside an attribute value, newlines and indentation includ
         {% endblock extra_js %}
         {% if STORK_SEARCH %}
             <script src="https://files.stork-search.net/releases/v1.6.0/stork.js"></script>
-            <script>stork.register("sitesearch", "{{ SITEURL }}/search-index.st")</script>
+            <script>
+                stork.register("sitesearch", "{{ SITEURL }}/search-index.st")
+            </script>
         {% endif %}
     </body>
 </html>


### PR DESCRIPTION
> [!TIP]
> Templates are reformatted by djlint, whose version is pinned by the `djlint` extra in `pyproject.toml`. Findings it cannot fix on its own are reported by the `lint-jinja` job.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/plumage/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`698d7fc6`](https://github.com/kdeldycke/plumage/commit/698d7fc6841a1b441e496bbeedd5d9ea0ee7b25e)
- **Job**: [`format-jinja`](https://github.com/kdeldycke/plumage/blob/698d7fc6841a1b441e496bbeedd5d9ea0ee7b25e/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/plumage/blob/698d7fc6841a1b441e496bbeedd5d9ea0ee7b25e/.github/workflows/autofix.yaml)
- **Run**: [#524.1](https://github.com/kdeldycke/plumage/actions/runs/31248512883)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.4.1`