### PR TITLE
Release `v5.0.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,6 @@
 # Changelog
 
-## [`5.0.0.dev0` (unreleased)](https://github.com/kdeldycke/plumage/compare/v4.0.0...main)
-
-> [!WARNING]
-> This version is **not released yet** and is under active development.
+## [`5.0.0` (2026-08-09)](https://github.com/kdeldycke/plumage/compare/v4.0.0...v5.0.0)
 
 - **Breaking:** Drop support for Python 3.9 and 3.10. The floor is now Python 3.11.
 - **Breaking:** Remove jQuery, `magnific-popup` and `mglass`, and the image auto-zoom they powered.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [`5.0.1.dev0` (unreleased)](https://github.com/kdeldycke/plumage/compare/v5.0.0...main)
+
+> [!WARNING]
+> This version is **not released yet** and is under active development.
+
 ## [`5.0.0` (2026-08-09)](https://github.com/kdeldycke/plumage/compare/v4.0.0...v5.0.0)
 
 - **Breaking:** Drop support for Python 3.9 and 3.10. The floor is now Python 3.11.

--- a/plumage/__init__.py
+++ b/plumage/__init__.py
@@ -17,7 +17,7 @@
 import logging
 from pathlib import Path
 
-__version__ = "5.0.0.dev0"
+__version__ = "5.0.0"
 """ Examples of valid version strings according :pep:`440#version-scheme`:
 
 .. code-block:: python

--- a/plumage/__init__.py
+++ b/plumage/__init__.py
@@ -17,7 +17,7 @@
 import logging
 from pathlib import Path
 
-__version__ = "5.0.0"
+__version__ = "5.0.1.dev0"
 """ Examples of valid version strings according :pep:`440#version-scheme`:
 
 .. code-block:: python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires = [ "uv-build>=0.8" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "plumage"
-version = "5.0.0.dev0"
+version = "5.0.0"
 description = "🪶 Clean and tidy theme for Pelican, the static site generator"
 readme = "readme.md"
 keywords = [
@@ -103,7 +103,7 @@ dependencies = [
 ]
 urls.Changelog = "https://github.com/kdeldycke/plumage/blob/main/changelog.md"
 urls.Documentation = "https://github.com/kdeldycke/plumage#settings"
-urls.Download = "https://github.com/kdeldycke/plumage/releases/tag/v5.0.0.dev0"
+urls.Download = "https://github.com/kdeldycke/plumage/releases/tag/v5.0.0"
 urls.Funding = "https://github.com/sponsors/kdeldycke"
 urls.Homepage = "https://github.com/kdeldycke/plumage"
 urls.Issues = "https://github.com/kdeldycke/plumage/issues"
@@ -256,7 +256,7 @@ ini_options.markers = [
 ini_options.xfail_strict = true
 
 [tool.bumpversion]
-current_version = "5.0.0.dev0"
+current_version = "5.0.0"
 # Parse versions with an optional .devN suffix (PEP 440).
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.dev(?P<dev>\\d+))?"
 serialize = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires = [ "uv-build>=0.8" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "plumage"
-version = "5.0.0"
+version = "5.0.1.dev0"
 description = "🪶 Clean and tidy theme for Pelican, the static site generator"
 readme = "readme.md"
 keywords = [
@@ -103,7 +103,7 @@ dependencies = [
 ]
 urls.Changelog = "https://github.com/kdeldycke/plumage/blob/main/changelog.md"
 urls.Documentation = "https://github.com/kdeldycke/plumage#settings"
-urls.Download = "https://github.com/kdeldycke/plumage/releases/tag/v5.0.0"
+urls.Download = "https://github.com/kdeldycke/plumage/releases/tag/v5.0.1.dev0"
 urls.Funding = "https://github.com/sponsors/kdeldycke"
 urls.Homepage = "https://github.com/kdeldycke/plumage"
 urls.Issues = "https://github.com/kdeldycke/plumage/issues"
@@ -256,7 +256,7 @@ ini_options.markers = [
 ini_options.xfail_strict = true
 
 [tool.bumpversion]
-current_version = "5.0.0"
+current_version = "5.0.1.dev0"
 # Parse versions with an optional .devN suffix (PEP 440).
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.dev(?P<dev>\\d+))?"
 serialize = [

--- a/uv.lock
+++ b/uv.lock
@@ -670,7 +670,7 @@ wheels = [
 
 [[package]]
 name = "plumage"
-version = "5.0.0"
+version = "5.0.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "cssmin" },

--- a/uv.lock
+++ b/uv.lock
@@ -10,9 +10,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
-[options.exclude-newer-package]
-repomatic = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-
 [manifest]
 overrides = [{ name = "myst-parser", specifier = ">=5" }]
 
@@ -673,7 +670,7 @@ wheels = [
 
 [[package]]
 name = "plumage"
-version = "5.0.0.dev0"
+version = "5.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "cssmin" },


### PR DESCRIPTION
This PR is ready to be merged. See the [`prepare-release` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-changelog-yaml-jobs) for details. The [merge event will trigger](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-release-yaml-jobs) the:

1. Creation of a `v5.0.0` tag on `main` branch
2. Build and release of the Python package to [PyPI](https://pypi.org)
3. Compilation of the project's binaries
4. Publication of a GitHub `v5.0.0` release with all artifacts above attached

## How-to release `v5.0.0`

1. Review the [`v5.0.0.dev0` GitHub release](https://github.com/kdeldycke/plumage/releases/tag/untagged-820a1244d14ea4e9a2b5)
1. Review the full changes: [`v4.0.0...main`](https://github.com/kdeldycke/plumage/compare/v4.0.0...main)
1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode
1. **Click `Rebase and merge`** button below

> [!CAUTION]
> Do not `Squash and merge`: [we need the 2 distinct commits](https://github.com/kdeldycke/repomatic/blob/main/docs/workflows.md#freeze-and-unfreeze-commits) in this PR.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/plumage/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`prepare-release`](https://kdeldycke.github.io/repomatic/workflows.html#prepare-release-prepare-release)
- **Trigger**: `workflow_run`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`aa177253`](https://github.com/kdeldycke/plumage/commit/aa1772533c3fac5cd7001b022020f74b3b180018)
- **Job**: [`prepare-release`](https://github.com/kdeldycke/plumage/blob/aa1772533c3fac5cd7001b022020f74b3b180018/.github/workflows/changelog.yaml)
- **Workflow**: [`changelog.yaml`](https://github.com/kdeldycke/plumage/blob/aa1772533c3fac5cd7001b022020f74b3b180018/.github/workflows/changelog.yaml)
- **Run**: [#123.1](https://github.com/kdeldycke/plumage/actions/runs/31327215749)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.8.0`