### PR TITLE
[changelog] Bump minor version to `v5.1.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`5.0.1.dev0` (unreleased)](https://github.com/kdeldycke/plumage/compare/v5.0.0...main)
+## [`5.1.0.dev0` (unreleased)](https://github.com/kdeldycke/plumage/compare/v5.0.0...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/plumage/__init__.py
+++ b/plumage/__init__.py
@@ -17,7 +17,7 @@
 import logging
 from pathlib import Path
 
-__version__ = "5.0.1.dev0"
+__version__ = "5.1.0.dev0"
 """ Examples of valid version strings according :pep:`440#version-scheme`:
 
 .. code-block:: python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires = [ "uv-build>=0.8" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "plumage"
-version = "5.0.1.dev0"
+version = "5.1.0.dev0"
 description = "🪶 Clean and tidy theme for Pelican, the static site generator"
 readme = "readme.md"
 keywords = [
@@ -104,7 +104,7 @@ dependencies = [
 ]
 urls.Changelog = "https://github.com/kdeldycke/plumage/blob/main/changelog.md"
 urls.Documentation = "https://github.com/kdeldycke/plumage#settings"
-urls.Download = "https://github.com/kdeldycke/plumage/releases/tag/v5.0.1.dev0"
+urls.Download = "https://github.com/kdeldycke/plumage/releases/tag/v5.1.0.dev0"
 urls.Funding = "https://github.com/sponsors/kdeldycke"
 urls.Homepage = "https://github.com/kdeldycke/plumage"
 urls.Issues = "https://github.com/kdeldycke/plumage/issues"
@@ -282,7 +282,7 @@ ini_options.markers = [
 ini_options.xfail_strict = true
 
 [tool.bumpversion]
-current_version = "5.0.1.dev0"
+current_version = "5.1.0.dev0"
 # Parse versions with an optional .devN suffix (PEP 440).
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.dev(?P<dev>\\d+))?"
 serialize = [

--- a/uv.lock
+++ b/uv.lock
@@ -686,7 +686,7 @@ wheels = [
 
 [[package]]
 name = "plumage"
-version = "5.0.1.dev0"
+version = "5.1.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "cssmin" },


### PR DESCRIPTION
Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-changelog-yaml-jobs) for details.

## To bump version to `v5.1.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/plumage/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`bump-version`](https://kdeldycke.github.io/repomatic/workflows.html#bump-version-bump-version)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`4c209503`](https://github.com/kdeldycke/plumage/commit/4c209503a913c41928076b7c0f319839741fdf7c)
- **Job**: [`bump-version`](https://github.com/kdeldycke/plumage/blob/4c209503a913c41928076b7c0f319839741fdf7c/.github/workflows/changelog.yaml)
- **Workflow**: [`changelog.yaml`](https://github.com/kdeldycke/plumage/blob/4c209503a913c41928076b7c0f319839741fdf7c/.github/workflows/changelog.yaml)
- **Run**: [#136.1](https://github.com/kdeldycke/plumage/actions/runs/31788269779)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.11.0`
