### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -40,7 +40,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       # Declared rather than inherited from the runner image, which ships whatever Node it was
       # built with and moves it without a commit here. Held to the major, so security patches
       # still arrive: sync-workflow-pins reads `uvx` and `npm install` literals, not this input,
@@ -87,7 +87,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Generate Pygments styles
         # Through Pygments' own API rather than a shell loop over `pygmentize -S`, which needed
         # jq to read the style listing. jq is whatever the runner image happens to ship, and
@@ -124,7 +124,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       # Same Node as the sync-vendored-assets job above, and for the same reason.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -171,7 +171,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Autofix Jinja
         # Pinned to the same release as the lint-jinja job in lint.yaml, which sync-workflow-pins
         # bumps in lockstep. Rules and profile come from [tool.djlint] in pyproject.toml.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,7 +44,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Lint Jinja
         # Version-pinned so sync-workflow-pins bumps it past the minimum-release-age cooldown.
         # Rules and profile come from [tool.djlint] in pyproject.toml. --github-output renders each

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -77,7 +77,7 @@ jobs:
           - "3.14"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Unittests


### PR DESCRIPTION
## 🆙 Updated actions

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `1 week`: releases after `2026-09-14` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) | [`v9.0.0` → `v10.1.0`](https://github.com/astral-sh/setup-uv/compare/v9.0.0...v10.1.0) | 2026-09-10 (a week ago) |

### Release notes

<details>
<summary><code>astral-sh/setup-uv</code></summary>

#### [`v10.0.0`](https://github.com/astral-sh/setup-uv/releases/tag/v10.0.0)

##### Changes

Another breaking release, directly after v9.0.0 but we think the added security justifies that.

###### Extra security by default

If you use the default `enable-cache: auto` this will now **DISABLE THE CACHE** to protect against cache poisoning for the following events:

- `pull_request_target`
- `workflow_run`
- `release`

You can read the full reasoning in https://redirect.github.com/astral-sh/setup-uv/issues/984

###### `version: latest-known`

```yaml
- name: Install the latest version of uv known to setup-uv
  uses: astral-sh/setup-uv@v10.0.0
  with:
    version: "latest-known"
```

This will now install the latest version with a checksum that is known by this action. The [known `uv` checksums](https://redirect.github.com/astral-sh/setup-uv/blob/4f6036f71cec78afb113b323f220c9185d983c12/src/download/checksum/known-checksums.ts) are automatically updated but will take a release of this action to take effect. You won't be always using the latest & greatest but you will have an extra level of security.

###### Read python version from `.tool-versions`

```yaml
- name: Install uv based on the version defined in .tool-versions and also set python
  uses: astral-sh/setup-uv@v10.0.0
  with:
    version-file: "pyproject.toml"
```

Will now also set the python version if it is defined in `.tool-versions`. You can read the details [in the docs](https://redirect.github.com/astral-sh/setup-uv/blob/main/docs/advanced-version-configuration.md#install-a-version-defined-in-a-requirements-or-config-file)

##### 🚨 Breaking changes

- Disable automatic caching for sensitive events @​eifinger (#​992)

##### 🐛 Bug fixes

- Reject paths in .tool-versions @​eifinger (#​1007)

##### 🚀 Enhancements

- Read Python version from .tool-versions @​eifinger (#​996)
- Add latest-known version selector @​eifinger (#​993)

##### 🧰 Maintenance

- Require pull requests for Dependabot rollups @​eifinger (#​1005)

... [Full release notes](https://github.com/astral-sh/setup-uv/releases/tag/v10.0.0)

#### [`v10.0.1`](https://github.com/astral-sh/setup-uv/releases/tag/v10.0.1)

##### Changes

Thank you @​arguile- for making this action more resilient.

##### 🐛 Bug fixes

- Tolerate transient manifest timeouts @​arguile- (#​1016)

##### 🧰 Maintenance

- chore: update known checksums for 0.12.4 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​1017)

##### 📚 Documentation

- docs: update version references to v10.0.0 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​1014)

#### [`v10.1.0`](https://github.com/astral-sh/setup-uv/releases/tag/v10.1.0)

##### Changes

This release adds more bheind the scene security improvements and also 2 small improvements.

###### NO_PROXY

This action now respects `no_proxy/NO_PROXY` environment variables which were previously ignored.

###### New output `python-runtime-id`

The new output `python-runtime-id` can be used to know which python version exactly was installed if you use `activate-environment`. See https://redirect.github.com/pyca/cryptography/pull/15572#discussion_r3913508686 for details on why this can be useful.

##### 🐛 Bug fixes

- fix: respect no proxy directive @​mj0nez (#​1037)
- Use JSON + a typed wrapper instead of TS codegen @​woodruffw (#​1025)

##### 🚀 Enhancements

- Expose a Python "identity" output @​woodruffw (#​1036)
- Verify downloads with astral-sh/versions checksums @​zaniebot (#​1033)

##### 🧰 Maintenance

- chore: update known checksums for 0.12.12 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​1041)
- chore: update known checksums for 0.12.10/0.12.11 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​1038)
- chore: update known checksums for 0.12.9 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​1035)
- chore: update known checksums for 0.12.7/0.12.8 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​1031)
- chore: update known checksums for 0.12.6 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​1030)
- chore: update known checksums for 0.12.5 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​1020)
- Use self-repo syntax for all in-repo actions/reusable workflows @​woodruffw (#​1024)
- Pin one-shot tools @​woodruffw (#​1022)
- ci: remove obsolete direct push attempts @​eifinger (#​1019)

##### 📚 Documentation

- docs: update version references to v10.0.1 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​1018)

... [Full release notes](https://github.com/astral-sh/setup-uv/releases/tag/v10.1.0)

</details>

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`action-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#action-pins-sync)
- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/plumage/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-action-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-action-pins-updater)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`4c209503`](https://github.com/kdeldycke/plumage/commit/4c209503a913c41928076b7c0f319839741fdf7c)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/plumage/blob/4c209503a913c41928076b7c0f319839741fdf7c/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/plumage/blob/4c209503a913c41928076b7c0f319839741fdf7c/.github/workflows/autofix.yaml)
- **Run**: [#549.1](https://github.com/kdeldycke/plumage/actions/runs/35586697990)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.11.0`
